### PR TITLE
Use the prerelease flag

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -2,6 +2,7 @@ name: imdg
 title: Hazelcast IMDG
 version: latest-dev
 display_version: '4.2-SNAPSHOT'
+prerelease: true
 asciidoc:
   attributes:
     javasource: ROOT:example$


### PR DESCRIPTION
Added the prerelease flag to the `latest-dev` version of the documentation to allow us to notify the user of such