### PR TITLE
Remove latest

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,6 @@
 name: imdg
 title: Hazelcast IMDG
-version: latest
-display_version: 4.1
+version: 4.1
 asciidoc:
   attributes:
     javasource: ROOT:example$


### PR DESCRIPTION
- Updated version 4.1 so that it no longer uses the `latest` alias