### PR TITLE
Do not use deprecated methods of ObjectDataInput/Output, PortableRead…

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -7,7 +7,8 @@ content:
     branches: HEAD
     start_path: docs
   - url: https://github.com/hazelcast/management-center-docs
-    branches: [main, v*]
+    branches: [main]
+    tags: [v*]
     start_path: docs
   - url: https://github.com/hazelcast/management-center-docs
     branches: [archive]

--- a/docs/modules/ROOT/examples/serialization/Address.java
+++ b/docs/modules/ROOT/examples/serialization/Address.java
@@ -16,17 +16,17 @@ public class Address implements DataSerializable {
     //getters setters..
 
     public void writeData( ObjectDataOutput out ) throws IOException {
-        out.writeUTF(street);
+        out.writeString(street);
         out.writeInt(zipCode);
-        out.writeUTF(city);
-        out.writeUTF(state);
+        out.writeString(city);
+        out.writeString(state);
     }
 
     public void readData( ObjectDataInput in ) throws IOException {
-        street = in.readUTF();
+        street = in.readString();
         zipCode = in.readInt();
-        city = in.readUTF();
-        state = in.readUTF();
+        city = in.readString();
+        state = in.readString();
     }
 }
 //end::address[]

--- a/docs/modules/ROOT/examples/serialization/EmployeePortable.java
+++ b/docs/modules/ROOT/examples/serialization/EmployeePortable.java
@@ -27,12 +27,12 @@ class EmployeePortable implements Portable {
     }
 
     public void writePortable(PortableWriter writer) throws IOException {
-        writer.writeUTF("n", name);
+        writer.writeString("n", name);
         writer.writeInt("a", age);
     }
 
     public void readPortable(PortableReader reader) throws IOException {
-        name = reader.readUTF("n");
+        name = reader.readString("n");
         age = reader.readInt("a");
     }
 

--- a/docs/modules/ROOT/examples/serialization/EmployeeStreamSerializer.java
+++ b/docs/modules/ROOT/examples/serialization/EmployeeStreamSerializer.java
@@ -16,13 +16,13 @@ public class EmployeeStreamSerializer
     @Override
     public void write( ObjectDataOutput out, EmployeeSS employee )
             throws IOException {
-        out.writeUTF(employee.getSurname());
+        out.writeString(employee.getSurname());
     }
 
     @Override
     public EmployeeSS read( ObjectDataInput in )
             throws IOException {
-        String surname = in.readUTF();
+        String surname = in.readString();
         return new EmployeeSS(surname);
     }
 

--- a/docs/modules/ROOT/examples/serialization/Foo.java
+++ b/docs/modules/ROOT/examples/serialization/Foo.java
@@ -30,12 +30,12 @@ public class Foo implements Portable {
 
     @Override
     public void writePortable( PortableWriter writer ) throws IOException {
-        writer.writeUTF( "foo", foo );
+        writer.writeString( "foo", foo );
     }
 
     @Override
     public void readPortable( PortableReader reader ) throws IOException {
-        foo = reader.readUTF( "foo" );
+        foo = reader.readString( "foo" );
     }
 }
 //end::fooportable[]

--- a/docs/modules/ROOT/examples/settingupclusters/IdentifiedEntryProcessor.java
+++ b/docs/modules/ROOT/examples/settingupclusters/IdentifiedEntryProcessor.java
@@ -21,11 +21,11 @@ public class IdentifiedEntryProcessor implements EntryProcessor<String, String, 
     }
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(value);
+        out.writeString(value);
     }
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        value = in.readUTF();
+        value = in.readString();
     }
     @Override
     public String process(Map.Entry<String, String> entry) {

--- a/docs/modules/clusters/pages/accessing-domain-objects.adoc
+++ b/docs/modules/clusters/pages/accessing-domain-objects.adoc
@@ -23,7 +23,7 @@ map.executeOnKey(key, (EntryProcessor<Object, Object, Object>) entry -> {
     Object value = entry.getValue();
     GenericRecord genericRecord = (GenericRecord) value;
 
-    int id = genericRecord.readInt("id");
+    int id = genericRecord.getInt("id");
 
     return null;
 });
@@ -40,16 +40,16 @@ from the clients and access them without using the User Code Deployment feature.
 With the introduction of `GenericRecord`, User Code Deployment should be used only for functional objects like `Runnable`,
 `Callable` and `EntryProcessor`.
 
-You can also create a `GenericRecord` in portable format with `GenericRecord.Builder` as follows:
+You can also create a `GenericRecord` in portable format with `GenericRecordBuilder` as follows:
 
 [source,java]
 ----
 ClassDefinition classDefinition = new ClassDefinitionBuilder(PORTABLE_FACTORY_ID, EMPLOYEE_CLASS_ID)
-                        .addUTFField("name").addIntField("id").build();
+                        .addStringField("name").addIntField("id").build();
 
-GenericRecord namedRecord = GenericRecord.Builder.portable(classDefinition)
-                .writeUTF("name", "foo")
-                .writeInt("id", 123).build();
+GenericRecord namedRecord = GenericRecordBuilder.portable(classDefinition)
+                .setString("name", "foo")
+                .setInt("id", 123).build();
 ----
 
 Note that the class definitions are better to be created once and
@@ -65,10 +65,10 @@ Instead you can create a builder from `GenericRecord` which carries the same cla
 map.executeOnKey("key", (EntryProcessor<Object, Object, Object>) entry -> {
             GenericRecord genericRecord = (GenericRecord) entry.getValue();
             GenericRecord modifiedGenericRecord = genericRecord.newBuilder()
-                    .writeUTF("name","Kermit")
-                    .writeLong("id", 4)
-                    .writeInt("age",20)
-                    .writeUTF("surname", "The Frog").build();
+                    .setString("name","Kermit")
+                    .setLong("id", 4)
+                    .setInt("age",20)
+                    .setString("surname", "The Frog").build();
             entry.setValue(modifiedGenericRecord);
             return null;
         });
@@ -84,7 +84,7 @@ both `classDefinition` and values from the original
 map.executeOnKey("key", (EntryProcessor<Object, Object, Object>) entry -> {
             GenericRecord genericRecord = (GenericRecord) entry.getValue();
             GenericRecord modifiedGenericRecord = genericRecord.cloneWithBuilder()
-                    .writeInt("age",22).build();
+                    .setInt("age",22).build();
             entry.setValue(modifiedGenericRecord);
             return null;
         });
@@ -99,11 +99,11 @@ An example code snippet on the client side with a map is shown below:
 [source,java]
 ----
         GenericRecord record = (GenericRecord) map.get("key1");
-        String name = record.readUTF("name");
-        int id = record.readInt("id");
+        String name = record.getString("name");
+        int id = record.getInt("id");
 
-        GenericRecord newGenericRecord = genericRecord.cloneWithBuilder()
-                .writeInt("age",22).build();
+        GenericRecord newGenericRecord = record.cloneWithBuilder()
+                .setInt("age",22).build();
 
         map.put("key2", newGenericRecord);
 ----

--- a/docs/modules/serialization/pages/implementing-dataserializable.adoc
+++ b/docs/modules/serialization/pages/implementing-dataserializable.adoc
@@ -38,16 +38,16 @@ public class Employee implements DataSerializable {
     //getters setters..
 
     public void writeData( ObjectDataOutput out ) throws IOException {
-        out.writeUTF(firstName);
-        out.writeUTF(lastName);
+        out.writeString(firstName);
+        out.writeString(lastName);
         out.writeInt(age);
         out.writeDouble (salary);
         address.writeData (out);
     }
 
     public void readData( ObjectDataInput in ) throws IOException {
-        firstName = in.readUTF();
-        lastName = in.readUTF();
+        firstName = in.readString();
+        lastName = in.readString();
         age = in.readInt();
         salary = in.readDouble();
         address = new Address();
@@ -116,13 +116,13 @@ public class Employee
     @Override
     public void readData( ObjectDataInput in )
       throws IOException {
-        this.surname = in.readUTF();
+        this.surname = in.readString();
     }
 
     @Override
     public void writeData( ObjectDataOutput out )
       throws IOException {
-        out.writeUTF( surname );
+        out.writeString( surname );
     }
 
     @Override

--- a/docs/modules/serialization/pages/implementing-portable-serialization.adoc
+++ b/docs/modules/serialization/pages/implementing-portable-serialization.adoc
@@ -270,12 +270,12 @@ public static class Foo implements Portable {
 
     @Override
     public void writePortable(PortableWriter writer) throws IOException {
-        writer.writeUTF("b", bar);
+        writer.writeString("b", bar);
     }
 
     @Override
     public void readPortable(PortableReader reader) throws IOException {
-        bar = reader.readUTF("b");
+        bar = reader.readString("b");
     }
 }
 
@@ -293,7 +293,7 @@ or manually register a class definition in serialization configuration as shown 
 ----
 Config config = new Config();
 final ClassDefinition classDefinition = new ClassDefinitionBuilder(FACTORY_ID, FOO_CLASS_ID)
-                       .addUTFField("b").build();
+                       .addStringField("b").build();
 config.getSerializationConfig().addClassDefinition(classDefinition);
 Hazelcast.newHazelcastInstance(config);
 ----

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "ISC",
   "scripts": {
     "build-local": "cross-env DOCSEARCH_ENABLED=true GOOGLE_ANALYTICS_KEY=GTM-M267KFN antora --to-dir test --fetch --generator @antora/site-generator-default antora-playbook-local.yml",
-    "check-links-local": "antora --generator @antora/xref-validator antora-playbook-local.yml",
+    "check-links-local": "antora --fetch --generator @antora/xref-validator antora-playbook-local.yml",
     "serve": "serve test",
     "expose": "ngrok http 5000"
   },


### PR DESCRIPTION
…er/Writer, and ClassDefinitionBuilder

We have deprecated methods containing `UTF` in their names and
introduced new methods that contain `String` instead of it in https://github.com/hazelcast/hazelcast/pull/18100.

This is a cleanup PR to use newly introduced methods instead of the
deprecated ones.

Also, fixed some generic record code samples.