### PR TITLE
Fix links to client documentation pages

### DIFF
--- a/docs/modules/events/pages/event-listeners-for-clients.adoc
+++ b/docs/modules/events/pages/event-listeners-for-clients.adoc
@@ -23,11 +23,11 @@ for more information.
 Follow the below links to learn how to configure the event listeners on other
 Hazelcast clients:
 
-* https://github.com/hazelcast/hazelcast-csharp-client#75-distributed-events[.NET client^]
-* https://github.com/hazelcast/hazelcast-cpp-client#75-distributed-events[C++ client^]
-* https://github.com/hazelcast/hazelcast-nodejs-client/blob/master/DOCUMENTATION.md#75-distributed-events[Node.js client^]
+* https://hazelcast.github.io/hazelcast-csharp-client/4.0.1/doc/events.html[.NET client^]
+* https://github.com/hazelcast/hazelcast-cpp-client/blob/master/Reference_Manual.md#75-distributed-events[C++ client^]
+* https://github.com/hazelcast/hazelcast-nodejs-client/blob/master/DOCUMENTATION.md#85-distributed-events[Node.js client^]
+* https://hazelcast.readthedocs.io/en/stable/using_python_client_with_hazelcast_imdg.html#distributed-events[Python client^]
 * https://github.com/hazelcast/hazelcast-go-client#75-distributed-events[Go client^]
-* https://github.com/hazelcast/hazelcast-python-client#75-distributed-events[Python client^]
 
 Note that you can simply add a listener to your client that you already configured
 and registered on the member side. You do not need to configure the listener on the client.

--- a/docs/modules/serialization/pages/implementing-dataserializable.adoc
+++ b/docs/modules/serialization/pages/implementing-dataserializable.adoc
@@ -219,8 +219,8 @@ the client side. For a Java client, the process is the same as described above t
 in the client configuration, e.g., `hazelcast-client.xml/yaml`.
 For the other Hazelcast clients, see the following for details:
 
-* https://github.com/hazelcast/hazelcast-csharp-client#41-identifieddataserializable-serialization[.NET^]
-* https://github.com/hazelcast/hazelcast-cpp-client#41-identifieddataserializable-serialization[C++^]
-* https://github.com/hazelcast/hazelcast-nodejs-client#41-identifieddataserializable-serialization[Node.js^]
-* https://github.com/hazelcast/hazelcast-python-client#41-identifieddataserializable-serialization[Python^]
+* https://hazelcast.github.io/hazelcast-csharp-client/4.0.1/doc/options.html#serialization[.NET^]
+* https://github.com/hazelcast/hazelcast-cpp-client/blob/master/Reference_Manual.md#41-identified_data_serializer-serialization[C++^]
+* https://github.com/hazelcast/hazelcast-nodejs-client/blob/master/DOCUMENTATION.md#41-identifieddataserializable-serialization[Node.js^]
+* https://hazelcast.readthedocs.io/en/stable/serialization.html#identifieddataserializable-serialization[Python^]
 * https://github.com/hazelcast/hazelcast-go-client#41-identifieddataserializable-serialization[Go^]


### PR DESCRIPTION
Similar to #156.

All clients except the Go client switched to using different places to host docs. As a result, all links that point to the homepage of a client's repository (e.g. `https://github.com/hazelcast/hazelcast-cpp-client#some-section`) were broken. This PR fixes all such errors.


