### PR TITLE
Improve WAN Tuning Page

### DIFF
--- a/docs/modules/wan/pages/tuning.adoc
+++ b/docs/modules/wan/pages/tuning.adoc
@@ -529,17 +529,17 @@ the batch size and benchmarking at high load.
 There are a couple of other configuration values that you might try changing but it depends on your use case.
 The first one is adding a separate configuration for a WAN replication executor.
 Collecting of WAN event batches and processing the responses from the target endpoints are done on a shared executor.
-This executor is shared between the other parts of the Hazelcast system and all of the WAN replication publishers will use
-the same executor. In some cases, you might want to create a dedicated executor for all WAN replication publishers.
-The name of this executor is `hz:wan`. Below is an example of a concrete, dedicated executor for WAN replication.
-See the xref:computing:executor-service.adoc#configuring-executor-service[Configuring Executor Service section] for more information on
-the configuration options of the executor.
+This executor is shared between the other parts of the Hazelcast system and all of the WAN replication publishers will
+use the same executor. In some cases, you might want to define how many threads WAN replication can use by setting the
+pool size of the dedicated executor for all WAN replication publishers. The name of this executor is `hz:wan`.
+Below is an example of a concrete, dedicated executor for WAN replication.
+See the xref:computing:executor-service.adoc#configuring-executor-service[Configuring Executor Service section] for more information on the configuration options of the executor.
 
-[tabs] 
-==== 
-XML:: 
-+ 
--- 
+[tabs]
+====
+XML::
++
+--
 [source,xml]
 ----
 <hazelcast>
@@ -562,6 +562,12 @@ hazelcast:
       pool-size: 16
 ----
 ====
+
+In this case, WAN replication is limited to use 16 threads at most, which is the default. Note that every configured WAN
+batch publisher occupies one thread from this pool, therefore, the pool size should have more threads than the number of
+the WAN batch publishers to leave threads available for processing other WAN related tasks such as asynchronously
+processing the answers of the WAN target clusters. The threads WAN uses are borrowed from a global thread pool to reduce
+the number of threads if possible.This means the threads running WAN related workload does not have any specific name.
 
 The last two elements that you might want to change are `acknowledge-type` and `max-concurrent-invocations`.
 Changing these elements allow you to get a greater throughput at the expense of event ordering.

--- a/docs/modules/wan/pages/tuning.adoc
+++ b/docs/modules/wan/pages/tuning.adoc
@@ -528,11 +528,10 @@ the batch size and benchmarking at high load.
 
 There are a couple of other configuration values that you might try changing but it depends on your use case.
 The first one is adding a separate configuration for a WAN replication executor.
-Collecting of WAN event batches and processing the responses from the target endpoints are done on a shared executor.
-This executor is shared between the other parts of the Hazelcast system and all of the WAN replication publishers will
-use the same executor. In some cases, you might want to define how many threads WAN replication can use by setting the
-pool size of the dedicated executor for all WAN replication publishers. The name of this executor is `hz:wan`.
-Below is an example of a concrete, dedicated executor for WAN replication.
+Collecting of WAN event batches and processing the responses from the target endpoints are done in a thread pool shared
+between the other parts of the Hazelcast system and all WAN replication schemes. In some cases, you might want to define
+how many threads WAN replication can use by setting the thread pool size of WAN's dedicated executor. The name of this
+executor is `hz:wan`. Below is an example of a concrete, dedicated executor for WAN replication.
 See the xref:computing:executor-service.adoc#configuring-executor-service[Configuring Executor Service section] for more information on the configuration options of the executor.
 
 [tabs]
@@ -564,10 +563,10 @@ hazelcast:
 ====
 
 In this case, WAN replication is limited to use 16 threads at most, which is the default. Note that every configured WAN
-batch publisher occupies one thread from this pool, therefore, the pool size should have more threads than the number of
-the WAN batch publishers to leave threads available for processing other WAN related tasks such as asynchronously
-processing the answers of the WAN target clusters. The threads WAN uses are borrowed from a global thread pool to reduce
-the number of threads if possible.This means the threads running WAN related workload does not have any specific name.
+batch publisher occupies one thread from the executor's pool, therefore, the pool should have more threads than the number
+of the configured WAN batch publishers to leave threads available for processing other WAN related tasks such as asynchronously processing the
+responses of the WAN target clusters. Since the threads WAN executor uses are borrowed from a global thread pool to
+reduce the number of threads in use, the threads running WAN tasks do not have any specific name.
 
 The last two elements that you might want to change are `acknowledge-type` and `max-concurrent-invocations`.
 Changing these elements allow you to get a greater throughput at the expense of event ordering.


### PR DESCRIPTION
It is a bit confusing for users that when they're configuring the pool size
of the dedicated WAN specific executor, the name of the threads used
for WAN replication don't get distinguished from the threads from other 
cached threads. This change aims to explain this with some other minor
improvements.