### PR TITLE
Fix IMap import statement in quickstart page

### DIFF
--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -103,7 +103,7 @@ Java::
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import com.hazelcast.map.IMap;
 
 public class MapSample {
     public static void main(String[] args) {


### PR DESCRIPTION
[IMap](https://docs.hazelcast.org/docs/latest-dev/javadoc/com/hazelcast/map/IMap.html) is at `com.hazelcast.map`.