### PR TITLE
Fix typo in supported-jvms.adoc

### DIFF
--- a/docs/modules/installation/pages/supported-jvms.adoc
+++ b/docs/modules/installation/pages/supported-jvms.adoc
@@ -15,7 +15,7 @@ This version has been tested against the following JDKs.
 
 |AdoptOpenJDK|8, 11, and later
 
-|Amazon Correcto|8 and 11
+|Amazon Corretto|8 and 11
 
 |Azul Zing|8
 


### PR DESCRIPTION
Amazon Correcto is not correct (pun intended). Should be Amazon Corretto (https://aws.amazon.com/corretto/).