### PR TITLE
zoom into replicated map guarantees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /node_modules/
 /test/
 package-lock.json
+.idea/
+*.iml

--- a/docs/modules/data-structures/pages/replicated-map.adoc
+++ b/docs/modules/data-structures/pages/replicated-map.adoc
@@ -99,7 +99,13 @@ is lost for the update. This leads to a break in the eventual consistency
 because different values can be read from the system for the same key.
 
 Other than the aforementioned scenario, the Replicated Map behaves
-like an eventually consistent system with read-your-writes and monotonic-reads consistency.
+like an eventually consistent system with monotonic-reads and best-effort
+read-your-writes consistency. Read-your-writes guarantee is not strict,
+and the reason is, since all writes for a single key are serialized
+through a given node N (unless there is a structural change in the cluster),
+it could be the case that node N is remote node which times out on successfully
+replicating the write request on the caller node, and thus caller node returns
+to the user rather than waiting indefinitely.
 
 [[configuration-design-for-replicated-map]]
 == Configuration Design for Replicated Map


### PR DESCRIPTION
More info in the following PR discussion https://github.com/hazelcast/hazelcast/pull/18985

But, basically, current replicated map implementation does not provide strict read-your-writes guarantee, there are some possible scenarios where user may not be able to read what is just wrote.