### PR TITLE
Changed keytabFile to keytab-file

### DIFF
--- a/docs/modules/security/pages/security-realms.adoc
+++ b/docs/modules/security/pages/security-realms.adoc
@@ -511,11 +511,11 @@ is not configured).
 | `principal`
 |
 | Kerberos principal name. This is a helper option which can be used together
-with the `keytabFile` to replace the `security-realm` configuration.
+with the `keytab-file` to replace the `security-realm` configuration.
 
 _We don't recommend using this property in production!_
 
-| `keytabFile`
+| `keytab-file`
 |
 | Path to a keytab file with the current principal's secrets.
 This is a helper option which can be used together
@@ -621,11 +621,11 @@ credentials, e.g., Keytab.
 | `principal`
 |
 | Kerberos principal name. This is a helper option which can be used together
-with the `keytabFile` to replace the `security-realm` configuration.
+with the `keytab-file` to replace the `security-realm` configuration.
 
 _We don't recommend using this property in production!_
 
-| `keytabFile`
+| `keytab-file`
 |
 | Path to a keytab file with the current principal's secrets.
 This is a helper option which can be used together
@@ -723,7 +723,7 @@ the member's Kerberos credentials to authenticate into the LDAP.
 
 To simplify the Kerberos configuration process for new users, Hazelcast allows
 skipping `Krb5LoginModule` JAAS configuration within separate security realms.
-Instead it's possible to define the `principal` and `keytabFile` options in the
+Instead it's possible to define the `principal` and `keytab-file` options in the
 `kerberos` identity and authentication configurations.
 If these options are used instead of the `security-realm`, then a new temporary
 realm is generated on the fly during the authentication.


### PR DESCRIPTION
There is no `keytabFile` element in http://www.hazelcast.com/schema/config/hazelcast-config-4.2.xsd but there is `keytab-file`.