### PR TITLE
Update location for .NET client documentation

### DIFF
--- a/docs/modules/clients/pages/dotnet.adoc
+++ b/docs/modules/clients/pages/dotnet.adoc
@@ -5,7 +5,7 @@ You can use the native .NET client to connect to Hazelcast client members.
 You need to add `HazelcastClient3x.dll` into your .NET project references.
 The API is very similar to the Java native client.
 
-See Hazelcast .NET client's own GitHub https://github.com/hazelcast/hazelcast-csharp-client[repo^]
-for information on configuring and starting the client.
+See Hazelcast .NET client's GitHub http://hazelcast.github.io/hazelcast-csharp-client/doc-index.html[documentation^]
+for more information on configuring, starting, and using the client.
 You can also find https://github.com/hazelcast/hazelcast-csharp-client/tree/master/src/Hazelcast.Net.Examples[code samples^]
-for this client in this repo.
+for the client in this repo.


### PR DESCRIPTION
Fixes #264 for the 4.2 documentation.