### PR TITLE
Update client internal thread pool defaults

### DIFF
--- a/docs/modules/clients/pages/java.adoc
+++ b/docs/modules/clients/pages/java.adoc
@@ -1208,7 +1208,7 @@ See the xref:serialization:serialization.adoc[Serialization chapter].
 [[executorpoolsize]]
 === Configuring Executor Pool Size
 
-Hazelcast has an internal executor service (different from the data structure *Executor Service*) that has threads and queues to perform internal operations such as handling responses. This parameter specifies the size of the pool of threads which perform these operations laying in the executor's queue. If not configured, this parameter has the value of **5 x core size of the client**, i.e., it is 20 for a machine that has 4 cores.
+Hazelcast has an internal executor service (different from the data structure *Executor Service*) that has threads and queues to perform internal operations such as handling responses. This parameter specifies the size of the pool of threads which perform these operations laying in the executor's queue. If not configured, this parameter has the value of **1 x core size of the client**, i.e., it is 4 for a machine that has 4 cores. (Please note that Java treats processor threads as cores, so on a hyperthreaded CPU it's possible to see twice the threads you expected.)
 
 [[classloader]]
 === Configuring ClassLoader


### PR DESCRIPTION
Fixes #285

(Also calls out why users might see double the threads they expected to see.)