### PR TITLE
Fix typo in jcache.adoc

### DIFF
--- a/docs/modules/jcache/pages/jcache.adoc
+++ b/docs/modules/jcache/pages/jcache.adoc
@@ -4,6 +4,6 @@
 This chapter describes the basics of JCache, the standardized Java caching layer API. The JCache
 caching API is specified by the Java Community Process (JCP) as Java Specification Request (JSR) 107.
 
-Caching keeps data in memory that either are slow to calculate/process or originate from another underlying backend system.
+Caching keeps data in memory that is either slow to calculate/process or originates from another underlying backend system.
 Caching is used to prevent additional request round trips for frequently used data. In both cases, caching can be used to
 gain performance or decrease application latencies.


### PR DESCRIPTION
Changed the first line of the second paragraph in order to make it more clear.