### PR TITLE
Centralise netlify build trigger

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   dispatch:
-    uses: hazelcast/hz-docs/.github/workflows/build-site-workflow.yml@master
+    uses: hazelcast/hz-docs/.github/workflows/build-site-workflow.yml@main
     secrets:
       netlify_build_hook_id: ${{ secrets.NETLIFY_BUILD_HOOK_ID }}

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   dispatch:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Trigger build
-      run: curl -d {} https://api.netlify.com/build_hooks/${{ secrets.NETLIFY_BUILD_HOOK_ID }}
-
+    uses: hazelcast/hz-docs/.github/workflows/build-site-workflow.yml@master
+    secrets:
+      netlify_build_hook_id: ${{ secrets.NETLIFY_BUILD_HOOK_ID }}


### PR DESCRIPTION
The netlify build trigger is trivial, but duplicated across many repos. This should be centralised to subsequently support refactoring to improve secret usage _in a single place_.